### PR TITLE
Fix autoconf configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_LANG(C++)
 
 AC_CHECK_HEADERS([triton/api.hpp], [], [AC_MSG_ERROR(No triton headers found)])
 
-LDFLAGS="$LDFALGS -ltriton"
+LIBS="$LIBS -ltriton"
 AC_LINK_IFELSE(
 	[AC_LANG_PROGRAM([#include <triton/api.hpp>
                       using namespace triton;],


### PR DESCRIPTION
Fix check failure when running `./configure` to build `vmtaint` from a fresh copy of `Ubuntu 20.04`.

Based on observations, the difference with the use of `LDFLAGS` and `LIBS` is the order of
of linker option.

`LDFLAGS` &rarr; `g++ -std=gnu++17 -o conftest -g -O2 -ltriton conftest.cpp` &rarr; undefined reference to `triton::API::API()` and `ttriton::API::~API()`

`LIBS` &rarr; `g++ -std=gnu++17 -o conftest -g -O2 conftest.cpp -ltriton` &rarr; build successful

`conftest.cpp`
```
#include <triton/api.hpp>
using namespace triton;
int main() {
    triton::API api;
    return 0; 
}  
```
It was also mentioned in the [autoconf documentation](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.71/autoconf.html#index-LDFLAGS-2) not to use `LDFLAGS` to pass library names to the linker.